### PR TITLE
ポーリング機能の追加

### DIFF
--- a/Detector/Detector.js
+++ b/Detector/Detector.js
@@ -5,5 +5,8 @@ module.exports = class Detector {
     this.detectorNumber = detectorNumber;
     this.detectorGrid = detectorGrid;
     this.detectorMap = detectorMap;
+
+    const date = new Date();
+    this.detectorActiveLastTime = date.getTime();
   }
 };

--- a/Detector/DetectorRepository.js
+++ b/Detector/DetectorRepository.js
@@ -67,4 +67,20 @@ module.exports = class DetectorRepository {
     client.close();
     return res.result;
   }
+
+  static async updateDetectorActiveLastTime(detectorData) {
+    const date = new Date();
+    const newDetectorActiveLastTime = date.getTime();
+
+    const client = await MongoClient.connect(DBURL)
+    .catch((err) => {
+      console.log(err);
+    });
+    const db = client.db(DBName);
+    const searchQuery = {detectorNumber: detectorData["detectorNumber"]};
+    const newValueQuery = { $set: { detectorActiveLastTime: newDetectorActiveLastTime } };
+    const res = await db.collection('detector').updateOne(searchQuery, newValueQuery);
+    client.close();
+    return res.result;
+  }
 };

--- a/index.js
+++ b/index.js
@@ -62,9 +62,14 @@ app.put('/api/detector/axis', (request, response) => {
     APIHandler.putDetector(request, response)
 });
 
+app.put('/api/detector/active', (request, response) => {
+    APIHandler.updateDetectorActiveLastTime(request, response)
+});
+
 app.delete('/api/detector', (request, response) => {
     APIHandler.deleteDetector(request, response)
 });
+
 //Map
 app.post('/api/map', (request, response) => {
     APIHandler.addMap(request, response)

--- a/service/APIHandlers.js
+++ b/service/APIHandlers.js
@@ -33,6 +33,15 @@ module.exports = class APIHandlers {
             });
     }
 
+
+    static updateDetectorActiveLastTime(req, res) {
+        const detector = req.body;
+        DetectorRepository.updateDetectorActiveLastTime(detector)
+            .then(() => {
+                res.send("Detector Active Time Updated!");
+            });
+    }
+
     static addMap(req, res) {
         const map = req.body;
         MapRepository.addMap(map)
@@ -113,7 +122,7 @@ module.exports = class APIHandlers {
 
     static putDetector(req, res) {
         const detector = req.body;
-        DetectorRepository.updateDetector(detector)   
+        DetectorRepository.updateDetector(detector)
             .then(() => {
                 res.send('Successfully put detector!');
             });


### PR DESCRIPTION
# 目的
各受信機から一定間隔で送られてくる生存信号をキャッチし、各受信機のステータスに反映する

# 背景
以前から受信機が生存しているかどうかは直接SSH接続で確認していたが、受信機が同一ネットワークに含まれなくなったので、確認が困難になった。