### PR TITLE
日時指定を日付指定に変更

### DIFF
--- a/Location/LocationRepository.js
+++ b/Location/LocationRepository.js
@@ -46,8 +46,14 @@ module.exports = class LocationRepository {
     client.close();
     let locations = [];
     for (let location of locationQuery) {
+      location.alert = false;
       locations.push(location);
     }
+    locations.forEach((location, idx) => {
+      if(locations[idx+1] && locations[idx].locatedTime - 15000 > locations[idx+1].locatedTime){
+        locations[idx+1].alert = true;
+      }
+    });
     return locations;
   }
 

--- a/webapp/src/Whereabouts/Map.js
+++ b/webapp/src/Whereabouts/Map.js
@@ -60,6 +60,17 @@ export default function sketch(p) {
             );
             p.tint('red');
             p.image(tracker.image, tracker.Location.grid.x, tracker.Location.grid.y);
+          }else if(tracker.Location.alert){
+            p.textSize(20);
+            p.fill(p.color('red'));
+            p.textAlign(p.LEFT, p.TOP);
+            p.text(
+              tracker.trackerName + 'さんを見失いました！',
+              tracker.Location.grid.x + 30,
+              tracker.Location.grid.y + 30
+            );
+            p.tint('red');
+            p.image(tracker.image, tracker.Location.grid.x, tracker.Location.grid.y);
           } else {
             p.noTint();
             p.image(tracker.image, tracker.Location.grid.x, tracker.Location.grid.y);

--- a/webapp/src/Whereabouts/Playback/SelectorBottom/SelectorBottom.js
+++ b/webapp/src/Whereabouts/Playback/SelectorBottom/SelectorBottom.js
@@ -10,6 +10,7 @@ export default function PlaybackSelectorBottom(props) {
   const [timeLine, setTimeLine] = useState([]);
   const [timerID, setTimerID] = useState(0);
   const [speed, setSpeed] = useState(1000);
+  const [errorTime, setErrorTime] = useState([]);
 
   useEffect(() => {
     const largestLocationTracker = _.max(props.trackers, tracker => {
@@ -18,12 +19,34 @@ export default function PlaybackSelectorBottom(props) {
     const times = _.map(largestLocationTracker.Location, location => {
       return location.locatedTime;
     });
+    times.reverse();
     setTimeLine(times);
+    //プレイバック機能のデータ飛び時の再生停止機能
+    //24時間分を超えると処理に時間がかかる
+    const errTimeLocation = _.map(largestLocationTracker.Location, location => {
+      if(location.alert){
+        return location.locatedTime;
+      }
+    });
+    const errorArray = [];
+    times.forEach((checkTime,idx) => {
+      if(errTimeLocation.includes(checkTime)){
+        errorArray.push(idx);
+      }
+    });
+    setErrorTime(errorArray);
   }, [props.trackers]);
 
   useEffect(() => {
     props.onChange(timeLine[time]);
   });
+
+  //プレイバック機能のデータ飛び時の再生停止機能
+  useEffect(() => {
+    if(errorTime.includes(refTime.current)){
+      clearInterval(timerID);
+    }
+  }, [refTime.current]);
 
   useEffect(() => {
     refTime.current = time;

--- a/webapp/src/Whereabouts/Playback/SelectorBottom/TimeSlider.js
+++ b/webapp/src/Whereabouts/Playback/SelectorBottom/TimeSlider.js
@@ -5,7 +5,7 @@ export default function TimeSlider(props) {
   const [timeLine, setTimeLine] = useState([]);
 
   useEffect(() => {
-    setTimeLine(props.timeline.reverse());
+    setTimeLine(props.timeline);
   }, [props.timeline]);
 
   const makeTimeString = millisec => {

--- a/webapp/src/Whereabouts/TermSelector.js
+++ b/webapp/src/Whereabouts/TermSelector.js
@@ -3,9 +3,12 @@ import Grid from '@material-ui/core/Grid';
 import DateFnsUtils from '@date-io/date-fns';
 import jaLocale from 'date-fns/locale/ja';
 import 'date-fns';
-import { DateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import { DatePicker, TimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 export default function MaterialUIPickers(props) {
+  const [selectDate, setSelectDate] = useState(new Date());
+  const [startTime, setStartTime] = useState(new Date());
+  const [endTime,setEndTime] = useState(new Date());
   const [startDate, setStartDate] = useState(new Date());
   const [endDate, setEndDate] = useState(new Date());
 
@@ -14,33 +17,70 @@ export default function MaterialUIPickers(props) {
       start: startDate.getTime(),
       end: endDate.getTime()
     };
+    console.log(term);
     props.onSend(term);
   };
+
+  useEffect(() => {
+    const selectStartDate = new Date();
+    selectStartDate.setFullYear(selectDate.getFullYear());
+    selectStartDate.setMonth(selectDate.getMonth());
+    selectStartDate.setDate(selectDate.getDate());
+    selectStartDate.setHours(startTime.getHours());
+    selectStartDate.setMinutes(startTime.getMinutes());
+    selectStartDate.setSeconds(startTime.getSeconds());
+    selectStartDate.setMilliseconds(startTime.getMilliseconds());
+    setStartDate(selectStartDate);
+  }, [selectDate, startTime]);
+
+  useEffect(() => {
+    const selectEndDate = new Date();
+    selectEndDate.setFullYear(selectDate.getFullYear());
+    selectEndDate.setMonth(selectDate.getMonth());
+    selectEndDate.setDate(selectDate.getDate());
+    selectEndDate.setHours(endTime.getHours());
+    selectEndDate.setMinutes(endTime.getMinutes());
+    selectEndDate.setSeconds(endTime.getSeconds());
+    selectEndDate.setMilliseconds(endTime.getMilliseconds());
+    setEndDate(selectEndDate);
+  }, [selectDate, endTime]);
 
   useEffect(send, [endDate]);
 
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils} locale={jaLocale}>
       <Grid container justify="space-around">
-        <DateTimePicker
+        <DatePicker
           variant="inline"
-          label="開始時間"
-          format="yyyy/MM/dd h:mm"
-          value={startDate}
+          label="日付"
+          format="yyyy/MM/dd"
+          value={selectDate}
           onChange={date => {
-            setStartDate(date);
-            setEndDate(date);
+            setSelectDate(date);
           }}
         />
       </Grid>
       <br />
       <Grid container justify="space-around">
-        <DateTimePicker
+        <TimePicker
+          variant="inline"
+          label="開始時間"
+          format="HH:mm"
+          value={startTime}
+          onChange={date => {
+            setStartTime(date);
+            setEndTime(date);
+          }}
+        />
+      </Grid>
+      <br />
+      <Grid container justify="space-around">
+        <TimePicker
           variant="inline"
           label="終了時間"
-          format="yyyy/MM/dd h:mm"
-          value={endDate}
-          onChange={date => setEndDate(date)}
+          format="HH:mm"
+          value={endTime}
+          onChange={date => setEndTime(date)}
         />
       </Grid>
     </MuiPickersUtilsProvider>

--- a/webapp/src/Whereabouts/TermSelector.js
+++ b/webapp/src/Whereabouts/TermSelector.js
@@ -17,7 +17,6 @@ export default function MaterialUIPickers(props) {
       start: startDate.getTime(),
       end: endDate.getTime()
     };
-    console.log(term);
     props.onSend(term);
   };
 

--- a/webapp/src/Whereabouts/TermSelector.js
+++ b/webapp/src/Whereabouts/TermSelector.js
@@ -7,42 +7,26 @@ import { DatePicker, TimePicker, MuiPickersUtilsProvider } from '@material-ui/pi
 
 export default function MaterialUIPickers(props) {
   const [selectDate, setSelectDate] = useState(new Date());
-  const [startTime, setStartTime] = useState(new Date());
-  const [endTime,setEndTime] = useState(new Date());
   const [startDate, setStartDate] = useState(new Date());
   const [endDate, setEndDate] = useState(new Date());
 
   const send = () => {
     const term = {
       start: startDate.getTime(),
-      end: endDate.getTime()
+      end: endDate
     };
     props.onSend(term);
   };
 
   useEffect(() => {
-    const selectStartDate = new Date();
-    selectStartDate.setFullYear(selectDate.getFullYear());
-    selectStartDate.setMonth(selectDate.getMonth());
-    selectStartDate.setDate(selectDate.getDate());
-    selectStartDate.setHours(startTime.getHours());
-    selectStartDate.setMinutes(startTime.getMinutes());
-    selectStartDate.setSeconds(startTime.getSeconds());
-    selectStartDate.setMilliseconds(startTime.getMilliseconds());
-    setStartDate(selectStartDate);
-  }, [selectDate, startTime]);
-
-  useEffect(() => {
-    const selectEndDate = new Date();
-    selectEndDate.setFullYear(selectDate.getFullYear());
-    selectEndDate.setMonth(selectDate.getMonth());
-    selectEndDate.setDate(selectDate.getDate());
-    selectEndDate.setHours(endTime.getHours());
-    selectEndDate.setMinutes(endTime.getMinutes());
-    selectEndDate.setSeconds(endTime.getSeconds());
-    selectEndDate.setMilliseconds(endTime.getMilliseconds());
-    setEndDate(selectEndDate);
-  }, [selectDate, endTime]);
+    startDate.setFullYear(selectDate.getFullYear());
+    startDate.setMonth(selectDate.getMonth());
+    startDate.setDate(selectDate.getDate());
+    startDate.setHours(0, 0, 0, 0);
+    setStartDate(startDate);
+    const endDate = startDate.getTime() + 86399999;
+    setEndDate(endDate);
+  }, [selectDate]);
 
   useEffect(send, [endDate]);
 
@@ -55,31 +39,9 @@ export default function MaterialUIPickers(props) {
           format="yyyy/MM/dd"
           value={selectDate}
           onChange={date => {
+            console.log(date);
             setSelectDate(date);
           }}
-        />
-      </Grid>
-      <br />
-      <Grid container justify="space-around">
-        <TimePicker
-          variant="inline"
-          label="開始時間"
-          format="HH:mm"
-          value={startTime}
-          onChange={date => {
-            setStartTime(date);
-            setEndTime(date);
-          }}
-        />
-      </Grid>
-      <br />
-      <Grid container justify="space-around">
-        <TimePicker
-          variant="inline"
-          label="終了時間"
-          format="HH:mm"
-          value={endTime}
-          onChange={date => setEndTime(date)}
         />
       </Grid>
     </MuiPickersUtilsProvider>

--- a/webapp/src/Whereabouts/TermSelector.js
+++ b/webapp/src/Whereabouts/TermSelector.js
@@ -3,7 +3,7 @@ import Grid from '@material-ui/core/Grid';
 import DateFnsUtils from '@date-io/date-fns';
 import jaLocale from 'date-fns/locale/ja';
 import 'date-fns';
-import { DatePicker, TimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 export default function MaterialUIPickers(props) {
   const [selectDate, setSelectDate] = useState(new Date());
@@ -39,7 +39,6 @@ export default function MaterialUIPickers(props) {
           format="yyyy/MM/dd"
           value={selectDate}
           onChange={date => {
-            console.log(date);
             setSelectDate(date);
           }}
         />


### PR DESCRIPTION
# 目的
のちに実装予定のlocationデータを日ごとに保存、読み込みする機能において日付を跨ぐと処理が面倒＆プレイバックのアラートの動作許容範囲が24時間くらい…なのを加味して日付指定して24時間取得するように変更しました
## DatePickerで実装
日付を取得することで0:00:00～23:59:99まで取得できるようにしました
### ブランチを並行で作業してたのをpullに合わせてマージしてしまったのでcommitが混ざってます